### PR TITLE
Implement ACEX Killtracker

### DIFF
--- a/addons/main/bootstrap.hpp
+++ b/addons/main/bootstrap.hpp
@@ -48,3 +48,12 @@ class Params {
         #endif
     };
 };
+
+#ifndef CUSTOMCFGDEBRIEFINGSECTIONS
+class CfgDebriefingSections {
+    class acex_killTracker {
+        title = "Acex Killed Events";
+        variable = "acex_killTracker_outputText";
+    };
+};
+#endif


### PR DESCRIPTION
ACEX killtracker provides a more accurate measure of how many kills you score at the end of the game. The vanilla system tends to miss kills caused by bleeding out, shrapnell and other ACE medical reasons.