### PR TITLE
CFP Loadout compat

### DIFF
--- a/addons/ai/functions/fnc_assignLoadout.sqf
+++ b/addons/ai/functions/fnc_assignLoadout.sqf
@@ -30,6 +30,11 @@ if (isNull _enabled || {getNumber _enabled != 1}) exitWith {};
 private _blacklisted = _unit getVariable [QGVAR(blacklistGear), false];
 if (_blacklisted) exitWith {};
 
+// Community Factions Project compatibility
+// Disable Randomisation
+if (isClass (configfile >> "CfgPatches" >> "cba_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
+//
+
 private _prioritizeTracerMags = getNumber (missionConfigFile >> "CfgARCMF" >> "AI" >> "Gear" >> _faction >> "prioritizeTracerMags") == 1;
 private _removeMedicalItems = getNumber (missionConfigFile >> "CfgARCMF" >> "AI" >> "Gear" >> _faction >> "removeMedicalItems") == 1;
 private _removeNightVision = getNumber (missionConfigFile >> "CfgARCMF" >> "AI" >> "Gear" >> _faction >> "removeNightVision") == 1;

--- a/addons/ai/functions/fnc_assignLoadout.sqf
+++ b/addons/ai/functions/fnc_assignLoadout.sqf
@@ -32,7 +32,7 @@ if (_blacklisted) exitWith {};
 
 // Community Factions Project compatibility
 // Disable Randomisation
-if (isClass (configfile >> "CfgPatches" >> "cba_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
+if (isClass (configfile >> "CfgPatches" >> "cfp_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
 //
 
 private _prioritizeTracerMags = getNumber (missionConfigFile >> "CfgARCMF" >> "AI" >> "Gear" >> _faction >> "prioritizeTracerMags") == 1;

--- a/addons/loadout/functions/fnc_assignLoadout.sqf
+++ b/addons/loadout/functions/fnc_assignLoadout.sqf
@@ -31,7 +31,7 @@ if (!local _unit) exitWith {
 
 // Community Factions Project compatibility
 // Disable Randomisation
-if (isClass (configfile >> "CfgPatches" >> "cba_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
+if (isClass (configfile >> "CfgPatches" >> "cfp_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
 //
 
 private _content = "";

--- a/addons/loadout/functions/fnc_assignLoadout.sqf
+++ b/addons/loadout/functions/fnc_assignLoadout.sqf
@@ -29,6 +29,11 @@ if (!local _unit) exitWith {
     _this remoteExecCall [QFUNC(assignLoadout), _unit];
 };
 
+// Community Factions Project compatibility
+// Disable Randomisation
+if (isClass (configfile >> "CfgPatches" >> "cba_main")) then {_unit setVariable ["CFP_DisableRandom", true, true]};
+//
+
 private _content = "";
 
 if (_role find ":" != -1) then {


### PR DESCRIPTION
CFP randomisation overwrites loadout assignment scripts, setting "CFP_DisableRandom" solves that.